### PR TITLE
Feature/com 48 create architectural structure of renderer

### DIFF
--- a/Rendering/Rendering.vcxproj
+++ b/Rendering/Rendering.vcxproj
@@ -17,7 +17,6 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
-
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>17.0</VCProjectVersion>
@@ -53,33 +52,31 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
-
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <ImportGroup Label="Shared" >
+  <ImportGroup Label="Shared">
   </ImportGroup>
-    <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-      <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    </ImportGroup>
-    <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-      <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    </ImportGroup>
-    <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-      <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    </ImportGroup>
-    <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-      <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    </ImportGroup>
-
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>include/</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -94,6 +91,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>include/</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -108,6 +106,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>include/</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -122,6 +121,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>include/</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -130,8 +130,33 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
-
-  <ItemGroup></ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="include\Objects\Camera.h" />
+    <ClInclude Include="include\Buffers\FrameBufferr.h" />
+    <ClInclude Include="include\Buffers\IndexBuffer.h" />
+    <ClInclude Include="include\Buffers\UniformBuffer.h" />
+    <ClInclude Include="include\Buffers\VertexBuffer.h" />
+    <ClInclude Include="include\Resources\Material.h" />
+    <ClInclude Include="include\Resources\Mesh.h" />
+    <ClInclude Include="include\Resources\Shader.h" />
+    <ClInclude Include="include\Resources\Texture.h" />
+    <ClInclude Include="include\Data\Vertex.h" />
+    <ClInclude Include="include\Objects\Light.h" />
+    <ClInclude Include="include\Buffers\VertexArray.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="src\Objects\Camera.cpp" />
+    <ClCompile Include="src\Objects\Light.cpp" />
+    <ClCompile Include="src\Resources\Material.cpp" />
+    <ClCompile Include="src\Resources\Mesh.cpp" />
+    <ClCompile Include="src\Resources\Shader.cpp" />
+    <ClCompile Include="src\Buffers\FrameBufferr.cpp" />
+    <ClCompile Include="src\Buffers\IndexBuffer.cpp" />
+    <ClCompile Include="src\Buffers\UniformBuffer.cpp" />
+    <ClCompile Include="src\Buffers\VertexBuffer.cpp" />
+    <ClCompile Include="src\Resources\Texture.cpp" />
+    <ClCompile Include="src\Buffers\VertexArray.cpp" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/Rendering/Rendering.vcxproj.filters
+++ b/Rendering/Rendering.vcxproj.filters
@@ -14,4 +14,77 @@
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="include\Buffers\FrameBufferr.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\Buffers\IndexBuffer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\Buffers\UniformBuffer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\Buffers\VertexBuffer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\Resources\Texture.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\Resources\Shader.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\Resources\Material.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\Resources\Mesh.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\Data\Vertex.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\Objects\Camera.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\Objects\Light.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\Buffers\VertexArray.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="src\Buffers\FrameBufferr.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\Buffers\IndexBuffer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\Buffers\UniformBuffer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\Buffers\VertexBuffer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\Resources\Texture.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\Resources\Shader.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\Resources\Material.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\Resources\Mesh.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\Objects\Camera.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\Objects\Light.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\Buffers\VertexArray.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
 </Project>

--- a/Rendering/include/Buffers/FrameBufferr.h
+++ b/Rendering/include/Buffers/FrameBufferr.h
@@ -1,0 +1,4 @@
+#pragma once
+class FrameBufferr
+{};
+

--- a/Rendering/include/Buffers/IndexBuffer.h
+++ b/Rendering/include/Buffers/IndexBuffer.h
@@ -1,0 +1,4 @@
+#pragma once
+class IndexBuffer
+{};
+

--- a/Rendering/include/Buffers/UniformBuffer.h
+++ b/Rendering/include/Buffers/UniformBuffer.h
@@ -1,0 +1,4 @@
+#pragma once
+class UniformBuffer
+{};
+

--- a/Rendering/include/Buffers/VertexArray.h
+++ b/Rendering/include/Buffers/VertexArray.h
@@ -1,0 +1,4 @@
+#pragma once
+class VertexArray
+{};
+

--- a/Rendering/include/Buffers/VertexBuffer.h
+++ b/Rendering/include/Buffers/VertexBuffer.h
@@ -1,0 +1,4 @@
+#pragma once
+class VertexBuffer
+{};
+

--- a/Rendering/include/Data/Vertex.h
+++ b/Rendering/include/Data/Vertex.h
@@ -1,0 +1,4 @@
+#pragma once
+struct Vertex
+{};
+

--- a/Rendering/include/Data/VertexBufferLayout.h
+++ b/Rendering/include/Data/VertexBufferLayout.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/Rendering/include/Objects/Camera.h
+++ b/Rendering/include/Objects/Camera.h
@@ -1,0 +1,4 @@
+#pragma once
+class Camera
+{};
+

--- a/Rendering/include/Objects/Light.h
+++ b/Rendering/include/Objects/Light.h
@@ -1,0 +1,4 @@
+#pragma once
+class Light
+{};
+

--- a/Rendering/include/Resources/Material.h
+++ b/Rendering/include/Resources/Material.h
@@ -1,0 +1,4 @@
+#pragma once
+class Material
+{};
+

--- a/Rendering/include/Resources/Mesh.h
+++ b/Rendering/include/Resources/Mesh.h
@@ -1,0 +1,4 @@
+#pragma once
+class Mesh
+{};
+

--- a/Rendering/include/Resources/Shader.h
+++ b/Rendering/include/Resources/Shader.h
@@ -1,0 +1,4 @@
+#pragma once
+class Shader
+{};
+

--- a/Rendering/include/Resources/Texture.h
+++ b/Rendering/include/Resources/Texture.h
@@ -1,0 +1,4 @@
+#pragma once
+class Texture
+{};
+

--- a/Rendering/src/Buffers/FrameBufferr.cpp
+++ b/Rendering/src/Buffers/FrameBufferr.cpp
@@ -1,0 +1,1 @@
+#include "Buffers/FrameBufferr.h"

--- a/Rendering/src/Buffers/IndexBuffer.cpp
+++ b/Rendering/src/Buffers/IndexBuffer.cpp
@@ -1,0 +1,1 @@
+#include "Buffers/IndexBuffer.h"

--- a/Rendering/src/Buffers/UniformBuffer.cpp
+++ b/Rendering/src/Buffers/UniformBuffer.cpp
@@ -1,0 +1,1 @@
+#include "Buffers/UniformBuffer.h"

--- a/Rendering/src/Buffers/VertexArray.cpp
+++ b/Rendering/src/Buffers/VertexArray.cpp
@@ -1,0 +1,1 @@
+#include "Buffers/VertexArray.h"

--- a/Rendering/src/Buffers/VertexBuffer.cpp
+++ b/Rendering/src/Buffers/VertexBuffer.cpp
@@ -1,0 +1,1 @@
+#include "Buffers/VertexBuffer.h"

--- a/Rendering/src/Objects/Camera.cpp
+++ b/Rendering/src/Objects/Camera.cpp
@@ -1,0 +1,1 @@
+#include "Objects/Camera.h"

--- a/Rendering/src/Objects/Light.cpp
+++ b/Rendering/src/Objects/Light.cpp
@@ -1,0 +1,1 @@
+#include "Objects/Light.h"

--- a/Rendering/src/Resources/Material.cpp
+++ b/Rendering/src/Resources/Material.cpp
@@ -1,0 +1,1 @@
+#include "Resources/Material.h"

--- a/Rendering/src/Resources/Mesh.cpp
+++ b/Rendering/src/Resources/Mesh.cpp
@@ -1,0 +1,1 @@
+#include "Resources/Mesh.h"

--- a/Rendering/src/Resources/Shader.cpp
+++ b/Rendering/src/Resources/Shader.cpp
@@ -1,0 +1,1 @@
+#include "Resources/Shader.h"

--- a/Rendering/src/Resources/Texture.cpp
+++ b/Rendering/src/Resources/Texture.cpp
@@ -1,0 +1,1 @@
+#include "Resources/Texture.h"


### PR DESCRIPTION
Add empty files for renderer architecture.
Minimum files needed for rendering a 2D triangle:
- Renderer.h/cpp
- VertexArray.h/cpp
- VertexBuffer.h/cpp
- Shader.h/cpp
- default.vert
- default.frag