### PR TITLE
[COM-98] Force Generators

### DIFF
--- a/Physics/Physics.vcxproj
+++ b/Physics/Physics.vcxproj
@@ -130,10 +130,12 @@
     <ClInclude Include="include\core.h" />
     <ClInclude Include="include\pointmass.h" />
     <ClInclude Include="include\precision.h" />
+	<ClInclude Include="include\pfgen.h" />
     <ClInclude Include="physics.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\pointmass.cpp" />
+	<ClCompile Include="src\pfgen.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Physics/Physics.vcxproj.filters
+++ b/Physics/Physics.vcxproj.filters
@@ -27,9 +27,15 @@
     <ClInclude Include="physics.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\pfgen.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\pointmass.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\pfgen.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Physics/include/core.h
+++ b/Physics/include/core.h
@@ -143,6 +143,11 @@ namespace AE86 {
 				x * vector.y - y * vector.x);
 		}
 
+		/** Zeroes the components of this vector. */
+		void clear() {
+			x, y, z = 0, 0, 0;
+		}
+
 	private:
 		/** Padding to ensure four word alignment. On many machines, four floating-point values
 		 *  sit cleaner in memory (memory is optimized for four sets of words). The speed ups from

--- a/Physics/include/core.h
+++ b/Physics/include/core.h
@@ -1,3 +1,7 @@
+#ifndef CORE_HEADER
+
+#define CORE_HEADER
+
 #include "precision.h"
 
 namespace AE86 {
@@ -172,3 +176,5 @@ namespace AE86 {
 		}
 	};
 }
+
+#endif

--- a/Physics/include/pfgen.h
+++ b/Physics/include/pfgen.h
@@ -1,0 +1,56 @@
+#include "core.h"
+#include "PointMass.h"
+#include <vector>
+namespace AE86
+{
+	class PointMassForceGenerator
+	{
+	public:
+		/**
+		* Overload this in implementations of the interface to calculate
+		* and update the force applied to the given PointMass.
+		*/
+		virtual void updateForce(PointMass* PointMass, real duration) = 0;
+	};
+	class PointMassForceRegistry
+	{
+	protected:
+		/**
+		* Keeps track of one force generator and the PointMass it
+		* applies to.
+		*/
+		struct PointMassForceRegistration
+		{
+			PointMass* pointMass;
+			PointMassForceGenerator* fg;
+		};
+		/**
+		* Holds the list of registrations.
+		*/
+		typedef std::vector<PointMassForceRegistration> Registry;
+		Registry registrations;
+	public:
+		/**
+		* Registers the given force generator to apply to the
+		* given PointMass.
+		*/
+		void add(PointMass* pointMass, PointMassForceGenerator* fg);
+		/**
+		* Removes the given registered pair from teh registry.
+		* If the pair is not registered, this method will have
+		* no effect.
+		*/
+		void remove(PointMass* pointMass, PointMassForceGenerator* fg);
+		/**
+		* Clears all registrations from the registry. This will
+		* not delete the PointMasss or the force generators
+		* themselves, just the records of their connection.
+		*/
+		void clear();
+		/**
+		* Calls all the force generators to update the forces of
+		* their corresponding PointMasss.
+		*/
+		void updateForces(real duration);
+	};
+}

--- a/Physics/include/pfgen.h
+++ b/Physics/include/pfgen.h
@@ -1,5 +1,9 @@
+#ifndef PFGEN_HEADER
+
+#define PFGEN_HEADER
+
 #include "core.h"
-#include "../include/pointmass.h"
+#include "pointmass.h"
 #include <vector>
 namespace AE86
 {
@@ -79,3 +83,5 @@ namespace AE86
 		void updateForces(real duration);
 	};
 }
+
+#endif

--- a/Physics/include/pfgen.h
+++ b/Physics/include/pfgen.h
@@ -1,5 +1,5 @@
 #include "core.h"
-#include "PointMass.h"
+#include "../include/pointmass.h"
 #include <vector>
 namespace AE86
 {
@@ -12,6 +12,18 @@ namespace AE86
 		*/
 		virtual void updateForce(PointMass* PointMass, real duration) = 0;
 	};
+
+	class PointMassGravity : public PointMassForceGenerator
+	{
+		/** Holds the acceleration due to gravity. */
+		Vector3 gravity;
+	public:
+		/** Creates the generator with the given acceleration. */
+		PointMassGravity(const Vector3& gravity);
+		/** Applies the gravitational force to the given particle. */
+		virtual void updateForce(PointMass* pointMass, real duration);
+	};
+
 	class PointMassForceRegistry
 	{
 	protected:

--- a/Physics/include/pfgen.h
+++ b/Physics/include/pfgen.h
@@ -24,6 +24,19 @@ namespace AE86
 		virtual void updateForce(PointMass* pointMass, real duration);
 	};
 
+    class PointMassDrag : public PointMassForceGenerator
+	{
+		/** Holds the velocity drag coefficient. */
+		real k1;
+		/** Holds the velocity squared drag coefficient. */
+		real k2;
+	public:
+		/** Creates the generator with the given coefficients. */
+		PointMassDrag(real k1, real k2);
+		/** Applies the drag force to the given particle. */
+		virtual void updateForce(PointMass* pointMass, real duration);
+	};
+
 	class PointMassForceRegistry
 	{
 	protected:

--- a/Physics/include/pointmass.h
+++ b/Physics/include/pointmass.h
@@ -15,6 +15,7 @@ namespace AE86 {
 		real getKineticEnergy();
 		void clearAccumulator();
 		void addForce(const Vector3& force);
+		void getVelocity(Vector3* velocity) const;
 
 	protected:
 		/**

--- a/Physics/include/pointmass.h
+++ b/Physics/include/pointmass.h
@@ -1,3 +1,7 @@
+#ifndef PM_HEADER
+
+#define PM_HEADER
+
 #include "core.h"
 
 namespace AE86 {
@@ -70,3 +74,5 @@ namespace AE86 {
 		Vector3 forceAccum;
 	};
 }
+
+#endif

--- a/Physics/include/pointmass.h
+++ b/Physics/include/pointmass.h
@@ -13,6 +13,9 @@ namespace AE86 {
 		void setMass(real mass);
 		void integrate(real duration);
 		real getKineticEnergy();
+		void clearAccumulator();
+		void addForce(const Vector3& force);
+
 	protected:
 		/**
 		 * Holds the linear positino of the particle
@@ -56,5 +59,12 @@ namespace AE86 {
 		 * (completely unstable in numerical simulation).
 		 */
 		real inverseMass;
+
+		/**
+		* Holds the accumulated force to be applied at the next
+		* simulation iteration only. This value is zeroed at each
+		* integration step.
+		*/
+		Vector3 forceAccum;
 	};
 }

--- a/Physics/include/pointmass.h
+++ b/Physics/include/pointmass.h
@@ -16,6 +16,7 @@ namespace AE86 {
 		void clearAccumulator();
 		void addForce(const Vector3& force);
 		void getVelocity(Vector3* velocity) const;
+		real getInverseMass();
 
 	protected:
 		/**

--- a/Physics/include/precision.h
+++ b/Physics/include/precision.h
@@ -1,3 +1,7 @@
+#ifndef PRECISION_HEADER
+
+#define PRECISION_HEADER
+
 #include <math.h>
 
 namespace AE86 {
@@ -12,3 +16,5 @@ namespace AE86 {
 	#define real_sqrt sqrtf
 	#define real_pow powf
 }
+
+#endif

--- a/Physics/src/pfgen.cpp
+++ b/Physics/src/pfgen.cpp
@@ -1,0 +1,10 @@
+#include "../include/pfgen.h"
+using namespace AE86;
+void PointMassForceRegistry::updateForces(real duration)
+{
+	Registry::iterator i = registrations.begin();
+	for (; i != registrations.end(); i++)
+	{
+		i->fg->updateForce(i->pointMass, duration);
+	}
+}

--- a/Physics/src/pfgen.cpp
+++ b/Physics/src/pfgen.cpp
@@ -18,3 +18,19 @@ void PointMassGravity::updateForce(PointMass* pointMass, real duration)
 	// particle->addForce(gravity * particle->getMass());
 	pointMass->addForce(gravity * (1 / pointMass->getInverseMass()));
 }
+
+void PointMassDrag::updateForce(PointMass* pointMass, real duration)
+{
+	Vector3 force;
+	// Points force to the value of the velocity of
+	// the particle
+	pointMass->getVelocity(&force);
+	// Calculate the total drag coefficient.
+	real dragCoeff = force.magnitude();
+	dragCoeff = k1 * dragCoeff + k2 * real_pow(dragCoeff, 2);
+	// Calculate the final force and apply it.
+	force.normalize();
+	force *= -dragCoeff;
+	pointMass->addForce(force);
+}
+

--- a/Physics/src/pfgen.cpp
+++ b/Physics/src/pfgen.cpp
@@ -8,3 +8,13 @@ void PointMassForceRegistry::updateForces(real duration)
 		i->fg->updateForce(i->pointMass, duration);
 	}
 }
+
+void PointMassGravity::updateForce(PointMass* pointMass, real duration)
+{
+	// Check that we do not have infinite mass.
+	// if (!particle->hasFiniteMass()) return;
+	if (pointMass->getInverseMass() <= 0.0) return;
+	// Apply the mass-scaled force to the particle.
+	// particle->addForce(gravity * particle->getMass());
+	pointMass->addForce(gravity * (1 / pointMass->getInverseMass()));
+}

--- a/Physics/src/pointmass.cpp
+++ b/Physics/src/pointmass.cpp
@@ -17,7 +17,7 @@ real PointMass::getKineticEnergy() {
 
 void PointMass::getVelocity(Vector3* velocity) const
 {
-	*velocity = Particle::velocity;
+	*velocity = PointMass::velocity;
 }
 
 real PointMass::getInverseMass()

--- a/Physics/src/pointmass.cpp
+++ b/Physics/src/pointmass.cpp
@@ -15,6 +15,10 @@ real PointMass::getKineticEnergy() {
 	return 0.5 * (1.0f / inverseMass) * velocity.magnitude();
 }
 
+void PointMass::getVelocity(Vector3* velocity) const
+{
+	*velocity = Particle::velocity;
+}
 
 void PointMass::integrate(real duration) {
 
@@ -44,7 +48,7 @@ void PointMass::clearAccumulator() {
 	forceAccum.clear();
 }
 
-void Particle::addForce(const Vector3& force)
+void PointMass::addForce(const Vector3& force)
 {
 	forceAccum += force;
 }

--- a/Physics/src/pointmass.cpp
+++ b/Physics/src/pointmass.cpp
@@ -35,4 +35,16 @@ void PointMass::integrate(real duration) {
 
 	// impose drag/damping
 	velocity *= real_pow(damping, duration);
+
+	// Clear the forces.
+	clearAccumulator();
+}
+
+void PointMass::clearAccumulator() {
+	forceAccum.clear();
+}
+
+void Particle::addForce(const Vector3& force)
+{
+	forceAccum += force;
 }

--- a/Physics/src/pointmass.cpp
+++ b/Physics/src/pointmass.cpp
@@ -20,6 +20,11 @@ void PointMass::getVelocity(Vector3* velocity) const
 	*velocity = Particle::velocity;
 }
 
+real PointMass::getInverseMass()
+{
+	return inverseMass;
+}
+
 void PointMass::integrate(real duration) {
 
 	// don't integrate if the particle has infinite mass


### PR DESCRIPTION
Added basic skeleton code for force generators on point masses. Then, instantiated gravity and drag force generators to be used on point masses for simulation purposes. Further documentation/theory can be found [here](https://publish.obsidian.md/shadow-moses/Physics/Overview).