### PR TITLE
[COM-102] Rotational Math

### DIFF
--- a/Physics/Physics.vcxproj
+++ b/Physics/Physics.vcxproj
@@ -136,6 +136,7 @@
     <ClInclude Include="include\pfgen.h" />
     <ClInclude Include="include\pworld.h" />
     <ClInclude Include="physics.h" />
+    <ClInclude Include="src\core.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\pcontacts.cpp" />

--- a/Physics/Physics.vcxproj.filters
+++ b/Physics/Physics.vcxproj.filters
@@ -39,6 +39,9 @@
     <ClInclude Include="include\pworld.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\core.cpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\pointmass.cpp">

--- a/Physics/include/core.h
+++ b/Physics/include/core.h
@@ -399,6 +399,33 @@ namespace AE86 {
 			result.data[11] = (o.data[3] * data[8]) + (o.data[7] * data[9]) + (o.data[11] * data[10]) + data[11];
 			return result;
 		}
+
+		/**
+		 * Returns the determinant of the matrix.
+		 */
+		real getDeterminant() const;
+
+		/**
+		 * Sets the matrix to be the inverse of the given matrix.
+		 */
+		void setInverse(const Matrix4& m);
+
+		/**
+		 * Returns a new matrix containing the inverse of this matrix.
+		 */
+		Matrix4 inverse() const {
+			Matrix4 result;
+			result.setInverse(*this);
+			return result;
+		}
+
+		/**
+		 * Inverts the matrix.
+		 */
+		void invert() {
+			setInverse(*this);
+		}
+
 	};
 }
 

--- a/Physics/include/core.h
+++ b/Physics/include/core.h
@@ -523,8 +523,68 @@ namespace AE86 {
 			);
 		}
 
+		/**
+		 * Transform the given vector by this matrix.
+		 */
 		Vector3 transform(const Vector3& vector) const {
 			return (*this) * vector;
+		}
+
+		/**
+		 * Transform the given vector by the transformational inverse
+		 * of this matrix.
+		 */
+		Vector3 transformInverse(const Vector3& vector) const {
+			Vector3 tmp = vector;
+			tmp.x -= data[3];
+			tmp.y -= data[7];
+			tmp.z -= data[11];
+			return Vector3(
+				tmp.x * data[0] +
+				tmp.y * data[4] +
+				tmp.z * data[8],
+				tmp.x * data[1] +
+				tmp.y * data[5] +
+				tmp.z * data[9],
+				tmp.x * data[2] +
+				tmp.y * data[6] +
+				tmp.z * data[10]
+			);
+		}
+
+		/**
+		 * Transform the given direction vector by this matrix.
+		 */
+		Vector3 transformDirection(const Vector3& vector) const {
+			return Vector3(
+				vector.x * data[0] +
+				vector.y * data[1] +
+				vector.z * data[2],
+				vector.x * data[4] +
+				vector.y * data[5] +
+				vector.z * data[6],
+				vector.x * data[8] +
+				vector.y * data[9] +
+				vector.z * data[10]
+			);
+		}
+
+		/**
+		 * Transform the given direction vector by the
+		 * transformational inverse of this matrix.
+		 */
+		Vector3 transformInverseDirection(const Vector3& vector) const {
+			return Vector3(
+				vector.x * data[0] +
+				vector.y * data[4] +
+				vector.z * data[8],
+				vector.x * data[1] +
+				vector.y * data[5] +
+				vector.z * data[9],
+				vector.x * data[2] +
+				vector.y * data[6] +
+				vector.z * data[10]
+			);
 		}
 
 		/**

--- a/Physics/include/core.h
+++ b/Physics/include/core.h
@@ -188,11 +188,13 @@ namespace AE86 {
 		 * Holds the tensor matrix data in array form.
 		 */
 		real data[9];
+
 		/**
 		 * Creates a new matrix.
 		 */
 		Matrix3() : data{} {
 		}
+
 		/**
 		 * Creates a new matrix with the given three vectors making
 		 * up its columns.
@@ -202,6 +204,7 @@ namespace AE86 {
 		{
 			setComponents(compOne, compTwo, compThree);
 		}
+
 		/**
 		 * Creates a new matrix with explicit coefficients.
 		 */
@@ -212,6 +215,7 @@ namespace AE86 {
 			data[3] = c3; data[4] = c4; data[5] = c5;
 			data[6] = c6; data[7] = c7; data[8] = c8;
 		}
+
 		/**
 		 * Sets the matrix values from the given three vector components.
 		 * These are arranged as the three columns of the vector.
@@ -232,6 +236,7 @@ namespace AE86 {
 			data[7] = compTwo.z;
 			data[8] = compThree.z;
 		}
+
 		/**
 		 * Transform the given vector by this matrix.
 		 */
@@ -304,6 +309,7 @@ namespace AE86 {
 		 * Holds the transform matrix data in array form.
 		 */
 		real data[12];
+
 		/**
 		 * Creates an identity matrix.
 		 */
@@ -313,6 +319,7 @@ namespace AE86 {
 				data[7] = data[8] = data[9] = data[11] = 0;
 			data[0] = data[5] = data[10] = 1;
 		}
+
 		/**
 		 * Transform the given vector by this matrix.
 		 */
@@ -329,9 +336,11 @@ namespace AE86 {
 				vector.z * data[10] + data[11]
 			);
 		}
+
 		Vector3 transform(const Vector3& vector) const {
 			return (*this) * vector;
 		}
+
 		/**
 		 * Returns a matrix, which is this one multiplied by the other given
 		 * matrix.

--- a/Physics/include/core.h
+++ b/Physics/include/core.h
@@ -329,6 +329,28 @@ namespace AE86 {
 		}
 
 		/**
+		 * Sets the matrix to be the transpose of the given matrix.
+		 */
+		void setTranspose(const Matrix3& m) {
+			data[0] = m.data[0];
+			data[1] = m.data[3];
+			data[2] = m.data[6];
+			data[3] = m.data[1];
+			data[4] = m.data[4];
+			data[5] = m.data[7];
+			data[6] = m.data[2];
+			data[7] = m.data[5];
+			data[8] = m.data[8];
+		}
+
+		/** Returns a new matrix containing the transpose of the matrix. */
+		Matrix3 transpose() const {
+			Matrix3 result;
+			result.setTranspose(*this);
+			return result;
+		}
+
+		/**
 		 * Transform the given vector by this matrix.
 		 */
 		Vector3 transform(const Vector3& vector) const {

--- a/Physics/include/core.h
+++ b/Physics/include/core.h
@@ -175,6 +175,186 @@ namespace AE86 {
 			z = -z;
 		}
 	};
+
+	/**
+	 * Holds a 3 x 3 row major matrix representing a transformation in
+	 * 3D space that does not include a translational component. This
+	 * matrix is not padded to produce an aligned structure.
+	 */
+	class Matrix3 {
+	public:
+		/**
+		 *
+		 * Holds the tensor matrix data in array form.
+		 */
+		real data[9];
+		/**
+		 * Creates a new matrix.
+		 */
+		Matrix3() : data{} {
+		}
+		/**
+		 * Creates a new matrix with the given three vectors making
+		 * up its columns.
+		 */
+		Matrix3(const Vector3& compOne, const Vector3& compTwo,
+			const Vector3& compThree) : data{}
+		{
+			setComponents(compOne, compTwo, compThree);
+		}
+		/**
+		 * Creates a new matrix with explicit coefficients.
+		 */
+		Matrix3(real c0, real c1, real c2, real c3, real c4, real c5,
+			real c6, real c7, real c8) : data{}
+		{
+			data[0] = c0; data[1] = c1; data[2] = c2;
+			data[3] = c3; data[4] = c4; data[5] = c5;
+			data[6] = c6; data[7] = c7; data[8] = c8;
+		}
+		/**
+		 * Sets the matrix values from the given three vector components.
+		 * These are arranged as the three columns of the vector.
+		 */
+		void setComponents(const Vector3& compOne, const Vector3& compTwo,
+			const Vector3& compThree)
+		{
+			// first row
+			data[0] = compOne.x;
+			data[1] = compTwo.x;
+			data[2] = compThree.x;
+			// second row
+			data[3] = compOne.y;
+			data[4] = compTwo.y;
+			data[5] = compThree.y;
+			// third row
+			data[6] = compOne.z;
+			data[7] = compTwo.z;
+			data[8] = compThree.z;
+		}
+		/**
+		 * Transform the given vector by this matrix.
+		 */
+		Vector3 operator*(const Vector3& vector) const {
+			return Vector3(
+				vector.x * data[0] + vector.y * data[1] + vector.z * data[2],
+				vector.x * data[3] + vector.y * data[4] + vector.z * data[5],
+				vector.x * data[6] + vector.y * data[7] + vector.z * data[8]
+			);
+		}
+		/**
+		 * Returns a matrix, which is this one multiplied by the other given
+		 * matrix.
+		 */
+		Matrix3 operator*(const Matrix3& o) const {
+			return Matrix3(
+				data[0] * o.data[0] + data[1] * o.data[3] + data[2] * o.data[6],
+				data[0] * o.data[1] + data[1] * o.data[4] + data[2] * o.data[7],
+				data[0] * o.data[2] + data[1] * o.data[5] + data[2] * o.data[8],
+				data[3] * o.data[0] + data[4] * o.data[3] + data[5] * o.data[6],
+				data[3] * o.data[1] + data[4] * o.data[4] + data[5] * o.data[7],
+				data[3] * o.data[2] + data[4] * o.data[5] + data[5] * o.data[8],
+				data[6] * o.data[0] + data[7] * o.data[3] + data[8] * o.data[6],
+				data[6] * o.data[1] + data[7] * o.data[4] + data[8] * o.data[7],
+				data[6] * o.data[2] + data[7] * o.data[5] + data[8] * o.data[8]
+			);
+		}
+		/**
+		 * Multiplies this matrix in place by the other given matrix.
+		 */
+		void operator*=(const Matrix3& o) {
+			real t1;
+			real t2;
+			real t3;
+			t1 = data[0] * o.data[0] + data[1] * o.data[3] + data[2] * o.data[6];
+			t2 = data[0] * o.data[1] + data[1] * o.data[4] + data[2] * o.data[7];
+			t3 = data[0] * o.data[2] + data[1] * o.data[5] + data[2] * o.data[8];
+			data[0] = t1;
+			data[1] = t2;
+			data[2] = t3;
+			t1 = data[3] * o.data[0] + data[4] * o.data[3] + data[5] * o.data[6];
+			t2 = data[3] * o.data[1] + data[4] * o.data[4] + data[5] * o.data[7];
+			t3 = data[3] * o.data[2] + data[4] * o.data[5] + data[5] * o.data[8];
+			data[3] = t1;
+			data[4] = t2;
+			data[5] = t3;
+			t1 = data[6] * o.data[0] + data[7] * o.data[3] + data[8] * o.data[6];
+			t2 = data[6] * o.data[1] + data[7] * o.data[4] + data[8] * o.data[7];
+			t3 = data[6] * o.data[2] + data[7] * o.data[5] + data[8] * o.data[8];
+			data[6] = t1;
+			data[7] = t2;
+			data[8] = t3;
+		}
+		/**
+		 * Transform the given vector by this matrix.
+		 */
+		Vector3 transform(const Vector3& vector) const {
+			return (*this) * vector;
+		}
+	};
+
+	/**
+	 * Holds a transform matrix, consisting of a rotatino matrix and
+	 * a position. The matrix has 12 elements, and it is assumed that the
+	 * remaining four are (0, 0, 0, 1), producing a homogeneous matrix.
+	 */
+	class Matrix4 {
+	public:
+		/**
+		 * Holds the transform matrix data in array form.
+		 */
+		real data[12];
+		/**
+		 * Creates an identity matrix.
+		 */
+		Matrix4()
+		{
+			data[1] = data[2] = data[3] = data[4] = data[6] =
+				data[7] = data[8] = data[9] = data[11] = 0;
+			data[0] = data[5] = data[10] = 1;
+		}
+		/**
+		 * Transform the given vector by this matrix.
+		 */
+		Vector3 operator*(const Vector3& vector) const {
+			return Vector3(
+				vector.x * data[0] +
+				vector.y * data[1] +
+				vector.z * data[2] + data[3],
+				vector.x * data[4] +
+				vector.y * data[5] +
+				vector.z * data[6] + data[7],
+				vector.x * data[8] +
+				vector.y * data[9] +
+				vector.z * data[10] + data[11]
+			);
+		}
+		Vector3 transform(const Vector3& vector) const {
+			return (*this) * vector;
+		}
+		/**
+		 * Returns a matrix, which is this one multiplied by the other given
+		 * matrix.
+		 */
+		Matrix4 operator*(const Matrix4& o) const {
+			Matrix4 result = Matrix4();
+			result.data[0] = (o.data[0] * data[0]) + (o.data[4] * data[1]) + (o.data[8] * data[2]);
+			result.data[4] = (o.data[0] * data[4]) + (o.data[4] * data[5]) + (o.data[8] * data[6]);
+			result.data[8] = (o.data[0] * data[8]) + (o.data[4] * data[9]) + (o.data[8] * data[10]);
+			result.data[1] = (o.data[1] * data[0]) + (o.data[5] * data[1]) + (o.data[9] * data[2]);
+			result.data[5] = (o.data[1] * data[4]) + (o.data[5] * data[5]) + (o.data[9] * data[6]);
+			result.data[9] = (o.data[1] * data[8]) + (o.data[5] * data[9]) + (o.data[9] * data[10]);
+			result.data[2] = (o.data[2] * data[0]) + (o.data[6] * data[1]) + (o.data[10] * data[2]);
+			result.data[6] = (o.data[2] * data[4]) + (o.data[6] * data[5]) + (o.data[10] * data[6]);
+			result.data[10] = (o.data[2] * data[8]) + (o.data[6] * data[9]) + (o.data[10] * data[10]);
+			result.data[3] = (o.data[3] * data[0]) + (o.data[7] * data[1]) + (o.data[11] * data[2]) + data[3];
+			result.data[7] = (o.data[3] * data[4]) + (o.data[7] * data[5]) + (o.data[11] * data[6]) + data[7];
+			result.data[11] = (o.data[3] * data[8]) + (o.data[7] * data[9]) + (o.data[11] * data[10]) + data[11];
+			return result;
+		}
+	};
 }
+
+
 
 #endif

--- a/Physics/include/core.h
+++ b/Physics/include/core.h
@@ -238,6 +238,41 @@ namespace AE86 {
 		}
 
 		/**
+		* Sets the matrix to be the inverse of the given matrix.
+		*/
+		void setInverse(const Matrix3& m)
+		{
+			real t1 = m.data[0] * m.data[4];
+			real t2 = m.data[0] * m.data[5];
+			real t3 = m.data[1] * m.data[3];
+			real t4 = m.data[2] * m.data[3];
+			real t5 = m.data[1] * m.data[6];
+			real t6 = m.data[2] * m.data[6];
+			// Calculate the determinant.
+			real det = (t1 * m.data[8] - t2 * m.data[7] - t3 * m.data[8] +
+				t4 * m.data[7] + t5 * m.data[5] - t6 * m.data[4]);
+			// Make sure the determinant is non-zero.
+			if (det == (real)0.0f) return;
+			real invd = (real)1.0f / det;
+			data[0] = (m.data[4] * m.data[8] - m.data[5] * m.data[7]) * invd;
+			data[1] = -(m.data[1] * m.data[8] - m.data[2] * m.data[7]) * invd;
+			data[2] = (m.data[1] * m.data[5] - m.data[2] * m.data[4]) * invd;
+			data[3] = -(m.data[3] * m.data[8] - m.data[5] * m.data[6]) * invd;
+			data[4] = (m.data[0] * m.data[8] - t6) * invd;
+			data[5] = -(t2 - t4) * invd;
+			data[6] = (m.data[3] * m.data[7] - m.data[4] * m.data[6]) * invd;
+			data[7] = -(m.data[0] * m.data[7] - t5) * invd;
+			data[8] = (t1 - t3) * invd;
+		}
+
+		/** Returns a new matrix containing the inverse of the matrix. */
+		Matrix3 inverse() const {
+			Matrix3 result;
+			result.setInverse(*this);
+			return result;
+		}
+
+		/**
 		 * Transform the given vector by this matrix.
 		 */
 		Vector3 operator*(const Vector3& vector) const {
@@ -247,6 +282,7 @@ namespace AE86 {
 				vector.x * data[6] + vector.y * data[7] + vector.z * data[8]
 			);
 		}
+
 		/**
 		 * Returns a matrix, which is this one multiplied by the other given
 		 * matrix.
@@ -264,6 +300,7 @@ namespace AE86 {
 				data[6] * o.data[2] + data[7] * o.data[5] + data[8] * o.data[8]
 			);
 		}
+
 		/**
 		 * Multiplies this matrix in place by the other given matrix.
 		 */
@@ -290,6 +327,7 @@ namespace AE86 {
 			data[7] = t2;
 			data[8] = t3;
 		}
+
 		/**
 		 * Transform the given vector by this matrix.
 		 */

--- a/Physics/src/core.cpp
+++ b/Physics/src/core.cpp
@@ -1,0 +1,48 @@
+#include "../include/core.h"
+
+namespace AE86 {
+
+    real Matrix4::getDeterminant() const {
+        return data[8] * data[5] * data[2] +
+            data[4] * data[9] * data[2] +
+            data[8] * data[1] * data[6] -
+            data[0] * data[9] * data[6] -
+            data[4] * data[1] * data[10] +
+            data[0] * data[5] * data[10];
+    }
+
+    void Matrix4::setInverse(const Matrix4& m) {
+        // make sure the determinant is non-zero.
+        real det = getDeterminant();
+        if (det == 0) return;
+        det = ((real)1.0f) / det;
+        data[0] = (-m.data[9] * m.data[6] + m.data[5] * m.data[10]) * det;
+        data[4] = (m.data[8] * m.data[6] - m.data[4] * m.data[10]) * det;
+        data[8] = (-m.data[8] * m.data[5] + m.data[4] * m.data[9]) * det;
+        data[1] = (m.data[9] * m.data[2] - m.data[1] * m.data[10]) * det;
+        data[5] = (-m.data[8] * m.data[2] + m.data[0] * m.data[10]) * det;
+        data[9] = (m.data[8] * m.data[1] - m.data[0] * m.data[9]) * det;
+        data[2] = (-m.data[5] * m.data[2] + m.data[1] * m.data[6]) * det;
+        data[6] = (+m.data[4] * m.data[2] - m.data[0] * m.data[6]) * det;
+        data[10] = (-m.data[4] * m.data[1] + m.data[0] * m.data[5]) * det;
+        data[3] = (m.data[9] * m.data[6] * m.data[3]
+            - m.data[5] * m.data[10] * m.data[3]
+            - m.data[9] * m.data[2] * m.data[7]
+            + m.data[1] * m.data[10] * m.data[7]
+            + m.data[5] * m.data[2] * m.data[11]
+            - m.data[1] * m.data[6] * m.data[11]) * det;
+        data[7] = (-m.data[8] * m.data[6] * m.data[3]
+            + m.data[4] * m.data[10] * m.data[3]
+            + m.data[8] * m.data[2] * m.data[7]
+            - m.data[0] * m.data[10] * m.data[7]
+            - m.data[4] * m.data[2] * m.data[11]
+            + m.data[0] * m.data[6] * m.data[11]) * det;
+        data[11] = (m.data[8] * m.data[5] * m.data[3]
+            - m.data[4] * m.data[9] * m.data[3]
+            - m.data[8] * m.data[1] * m.data[7]
+            + m.data[0] * m.data[9] * m.data[7]
+            + m.data[4] * m.data[1] * m.data[11]
+            - m.data[0] * m.data[5] * m.data[11]) * det;
+    }
+
+}


### PR DESCRIPTION
Expanded Physics' internal math library to include 3x3 matrices, 4x4 matrices, and quaternions. Motivation for doing so rather than just using GLM was for learning purposes. For example, to optimize the 4x4 matrices in our internal math library they are actually 4x3 matrices in column-major ordering, with the final row of [0, 0, 0, 1] being implicit in all calculations. This saves us having to store four extra doubles. 

The trade-off for this is we have hard-coded methods for transformations on directions vs points, but we save much more space doing so.

I forgot to prepend all of my commit messages with [COM-102][JS], sorry for that.