### PR TITLE
[COM-153][COM-175] Fix transform hierarchy

### DIFF
--- a/Core/include/Components/TransformComponent.h
+++ b/Core/include/Components/TransformComponent.h
@@ -38,17 +38,18 @@ public:
     // lock to guarantee mutual exclusion
     std::mutex mtx;
 
-    /** the parent might move or scale, the transform matrix needs
-     * to then be updated. This method does that.
-     */
-    void updateTransformMatrix();
     void lookAt(TransformComponent* target);
 
 
     /********************************************/
     /* SETTERS AND GETTERS FOR POS/ORIENT/SCALE */
     /********************************************/
-    inline const glm::mat4 getTransformMatrix() { return transformMatrix; }
+
+    // returns a 4x4 transformation matrix local to the parent
+    const glm::mat4 getLocalTransformMatrix();
+
+    // returns a world transformation matrix
+    const glm::mat4 getTransformMatrix();
 
     glm::vec3 getWorldPosition();
     glm::quat getWorldOrientation() const;

--- a/Core/src/Components/TransformComponent.cpp
+++ b/Core/src/Components/TransformComponent.cpp
@@ -127,9 +127,9 @@ glm::vec3 TransformComponent::getLocalScale() const {
 }
 
 void TransformComponent::setLocalScale(glm::vec3 scale) {
-	localOrientation.x = scale.x;
-	localOrientation.y = scale.y;
-	localOrientation.z = scale.z;
+	localScale.x = scale.x;
+	localScale.y = scale.y;
+	localScale.z = scale.z;
 }
 
 TransformComponent& TransformComponent::operator=(const TransformComponent& other)

--- a/Core/src/Components/TransformComponent.cpp
+++ b/Core/src/Components/TransformComponent.cpp
@@ -19,7 +19,6 @@ TransformComponent::TransformComponent(Entity* mEntity) :Component(mEntity), loc
 TransformComponent::TransformComponent(Entity* mEntity, glm::vec4 position, glm::quat orientation, float scale)
 	: Component(mEntity), localPosition(position), localOrientation(orientation), localScale(scale)
 {
-    updateTransformMatrix();
 
     // DO NOT REVERSE LINK mEntity->transform = this. This should be handled in Entity's initialization.
 }
@@ -28,32 +27,25 @@ TransformComponent::~TransformComponent()
 {
 }
 
-void TransformComponent::updateTransformMatrix()
-{
-    if (entity->getParent() == nullptr)
-    {
-        transformMatrix = glm::mat4(1.0f); // identity matrix
-    }
-    else
-    {
-        glm::mat4 parentTransformMatrix = entity->getParent()->transform->getTransformMatrix();
-        glm::vec3 parentLocationXYZ = entity->getParent()->transform->getLocalPosition().xyz;
-        glm::quat parentOrientation = entity->getParent()->transform->getLocalOrientation();
+const glm::mat4 TransformComponent::getLocalTransformMatrix() {
+    // right-to-left linear transformations: scale, rotate, translate    
+    return
+        glm::translate(glm::mat4(1.0f), localPosition) *
+        glm::mat4_cast(localOrientation) *
+        glm::mat4(
+            glm::vec4(localScale.x, 0.0f, 0.0f, 0.0f),
+            glm::vec4(0.0f, localScale.y, 0.0f, 0.0f),
+            glm::vec4(0.0f, 0.0f, localScale.z, 0.0f),
+            glm::vec4(0.0f, 0.0f, 0.0f, 1.0f)
+        );
+}
 
-        transformMatrix = parentTransformMatrix *
-            // scale, rotate, translate matrix for parent: 
-            (
-                // creates a translation matrix
-                glm::translate(glm::mat4(1.0f), parentLocationXYZ) *
-                glm::mat4_cast(parentOrientation) * // gets a rotation matrix from the quaternion
-                glm::mat4( // creates a scale matrix 
-                    glm::vec4(entity->getParent()->transform->localScale.x, 0.0f, 0.0f, 0.0f),
-                    glm::vec4(0.0f, entity->getParent()->transform->localScale.y, 0.0f, 0.0f),
-                    glm::vec4(0.0f, 0.0f, entity->getParent()->transform->localScale.z, 0.0f),
-                    glm::vec4(0.0f, 0.0f, 0.0f, 1.0f)
-                )
-                );
-    }
+const glm::mat4 TransformComponent::getTransformMatrix() {
+    auto parent = this->entity->getParent();
+    if (parent)
+        return parent->transform->getTransformMatrix() * getLocalTransformMatrix();
+    else
+        return getLocalTransformMatrix();
 }
 
 void TransformComponent::lookAt(TransformComponent* target)

--- a/Physics/Physics.h
+++ b/Physics/Physics.h
@@ -74,7 +74,6 @@ public:
 
         CAR_TRANSFORM->setLocalPosition(glm::vec3(updatedPosition.x, updatedPosition.y, updatedPosition.z));
         CAR_TRANSFORM->setLocalOrientation(glm::quat(updatedOrientation.r, updatedOrientation.i, updatedOrientation.j, updatedOrientation.k));
-        CAR_TRANSFORM->updateTransformMatrix();
         std::cout << "PHYSICS - WE HAVE UPDATED THE TRANSFORM AND RELEASING LOCK\n";
     }
 


### PR DESCRIPTION
The transform hierarchy now works. Previously each TransformComponent had an updateTransformMatrix method. The plan was to call every child TransformComponent's updater whenever a parent's position, orientation, or scale was changed. 

It's a simple in-order traversal but would require the scene graph to be locked while it happens and might be premature optimization for optimization's sake (we won't have that many entities in our game anyways).

So getTransformMatrix simply recursively constructs a world matrix by bubbling up to the node's parents (and not their un-keels).