### PR TITLE
Feature/com 217 change parent

### DIFF
--- a/UI/include/Inspector.h
+++ b/UI/include/Inspector.h
@@ -3,7 +3,9 @@
 #define INSPECTOR_H
 
 #include <imgui.h>
+#include "Scene.h"
 
-void drawInspector();
+void drawInspector(Scene* scene);
+void drawTransform();
 
 #endif

--- a/UI/src/DKWindows.cpp
+++ b/UI/src/DKWindows.cpp
@@ -50,7 +50,7 @@ void createImGuiWindows(Scene* scene) {
 
    drawViewport();
    drawHierarchy(scene);
-   drawInspector();
+   drawInspector(scene);
    drawBrowser();
    drawConsole();
 

--- a/UI/src/Hierarchy.cpp
+++ b/UI/src/Hierarchy.cpp
@@ -21,6 +21,10 @@ void drawHierarchyLine(Entity* entity) {
         nodeFlags |= ImGuiTreeNodeFlags_Selected;
     }
 
+    if (entity->getChildren().size() == 0) {
+       nodeFlags |= ImGuiTreeNodeFlags_Leaf;
+    }
+
     // Create a unique ID using the name and the memory address of the GameObject
     ImGui::PushID(entity->GetEntityID().str().c_str()); // Push the GameObject pointer to the ID stack
     bool nodeOpen = ImGui::TreeNodeEx(entity->GetDisplayName().c_str(), nodeFlags);

--- a/UI/src/Hierarchy.cpp
+++ b/UI/src/Hierarchy.cpp
@@ -8,6 +8,7 @@
 using namespace std;
 
 Entity* selectedEntity = nullptr;
+Entity* rootEntity = nullptr;
 
 // Global variable to track the renaming state
 Entity* renamingEntity = nullptr; // Currently selected GameObject for renaming
@@ -31,7 +32,7 @@ void drawHierarchyLine(Entity* entity) {
     ImGui::PopID(); // Pop the ID from the stack
 
     // Handle left-click selection
-    if (ImGui::IsItemClicked() && !ImGui::IsItemToggledOpen()) {
+    if (ImGui::IsItemHovered() && ImGui::IsMouseReleased(ImGuiMouseButton_Left) && !ImGui::IsItemToggledOpen() && !ImGui::IsMouseDragging(ImGuiMouseButton_Left)) {
         selectedEntity = entity;
         consoleLog("Selected: " + entity->GetDisplayName());
 
@@ -107,6 +108,33 @@ void drawHierarchyLine(Entity* entity) {
         }
     }
 
+    if (entity != rootEntity && ImGui::BeginDragDropSource()) {
+       ImGui::SetDragDropPayload("Entity", &entity, sizeof(Entity*));
+       ImGui::Text(entity->GetDisplayName().c_str());
+       ImGui::EndDragDropSource();
+    }
+
+    if (ImGui::BeginDragDropTarget()) {
+       const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("Entity");
+       if (payload != nullptr) {
+          Entity* child = *(Entity**)payload->Data;
+          Entity* parent = entity;
+          Entity* parentTree = parent;
+          while (parentTree != rootEntity && parentTree != child) { //check for parent loop
+             parentTree = parentTree->getParent();
+          }
+          if (parentTree == child) {
+             consoleLog("Error: reparenting " + child->GetDisplayName() + " to " + parent->GetDisplayName() + " would cause hierarchy loop");
+          }
+          else if (child != parent) {
+             child->setParent(parent);
+             consoleLog(child->GetDisplayName() + " parented to " + parent->GetDisplayName());
+          }
+       }
+       ImGui::EndDragDropTarget();
+    }
+
+
     // Draw children recursively if the node is open
     if (nodeOpen) {
        for (int i = 0; i < entity->getChildren().size(); i++) {
@@ -120,7 +148,7 @@ void drawHierarchyLine(Entity* entity) {
 void drawHierarchy(Scene* scene) {
     ImGui::Begin("Hierarchy");
 
-    Entity* rootEntity = scene->getRoot();
+    rootEntity = scene->getRoot();
 
     if (rootEntity) {
        drawHierarchyLine(rootEntity);

--- a/UI/src/Inspector.cpp
+++ b/UI/src/Inspector.cpp
@@ -7,7 +7,7 @@
 #include <gtc/type_ptr.hpp>
 #include <gtc/quaternion.hpp>
 
-void drawInspector() {
+void drawInspector(Scene* scene) {
    //Get object information and display
    ImGui::Begin("Inspector");
    Entity* selectedEntity = getSelectedEntity();  // Use the new function
@@ -28,48 +28,73 @@ void drawInspector() {
            ImGui::Text("Parent: ");
            ImGui::SameLine(75);
            if (selectedEntity->getParent() != nullptr) {
-               ImGui::Text("%s", selectedEntity->getParent()->GetDisplayName().c_str());
+               ImGui::Selectable(selectedEntity->getParent()->GetDisplayName().c_str());
            }
            else {
-               ImGui::Text("Root");
+               ImGui::Selectable("None");
            }
+
+           if (selectedEntity != scene->getRoot() && ImGui::BeginDragDropTarget()) {
+              const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("Entity");
+              if (payload != nullptr) {
+                 Entity* parent = *(Entity**)payload->Data;
+                 Entity* child = selectedEntity;
+                 Entity* parentTree = parent;
+                 while (parentTree != scene->getRoot() && parentTree != child) { //check for parent loop
+                    parentTree = parentTree->getParent();
+                 }
+                 if (parentTree == child) {
+                    consoleLog("Error: reparenting " + child->GetDisplayName() + " to " + parent->GetDisplayName() + " would cause hierarchy loop");
+                 }
+                 else if (child != parent) {
+                    child->setParent(parent);
+                    consoleLog(child->GetDisplayName() + " parented to " + parent->GetDisplayName());
+                 }
+              }
+              ImGui::EndDragDropTarget();
+           }
+
        }
-       //ImGui::Text("Selected Object: %s", selected->getName().c_str());
 
-       if (ImGui::CollapsingHeader("Transform", ImGuiTreeNodeFlags_DefaultOpen)) {
-          TransformComponent* transform = selectedEntity->transform;
-          if (transform != nullptr) {
-
-             // Position
-             glm::vec3 position = transform->getLocalPosition();
-             ImGui::Text("Position");
-             ImGui::SameLine(75); // Adjust the value (100) to set appropriate spacing for label alignment
-             if(ImGui::DragFloat3("##Position", glm::value_ptr(position), 0.1f)) {
-                  transform->setLocalPosition(position);
-             }
-
-             // Rotation
-             glm::vec3 rotation = glm::degrees(glm::eulerAngles(transform->getLocalOrientation()));
-             ImGui::Text("Rotation");
-             ImGui::SameLine(75);
-             if (ImGui::DragFloat3("##Rotation", glm::value_ptr(rotation), 0.1f)) {
-
-                 transform->setLocalOrientation(glm::quat(glm::radians(rotation)));
-             }
-
-             // Scale
-             glm::vec3 scale = transform->getLocalScale();
-             ImGui::Text("Scale");
-             ImGui::SameLine(75);
-             if (ImGui::DragFloat3("##Scale", glm::value_ptr(scale), 0.1f)) {
-                transform->setLocalScale(scale);
-             }
-          }
-       }
+       drawTransform();
+       //TODO: Check for which components an entity has and call the approprite function to draw
+       
    }
    else {
-       ImGui::Text("No Game Object Selected");
+       ImGui::Text("No Entity Selected");
    }
    ImGui::End();
 }
 
+void drawTransform() {
+   if (ImGui::CollapsingHeader("Transform", ImGuiTreeNodeFlags_DefaultOpen)) {
+      TransformComponent* transform = getSelectedEntity()->transform;
+      if (transform != nullptr) {
+
+         // Position
+         glm::vec3 position = transform->getLocalPosition();
+         ImGui::Text("Position");
+         ImGui::SameLine(75); // Adjust the value (100) to set appropriate spacing for label alignment
+         if (ImGui::DragFloat3("##Position", glm::value_ptr(position), 0.1f)) {
+            transform->setLocalPosition(position);
+         }
+
+         // Rotation
+         glm::vec3 rotation = glm::degrees(glm::eulerAngles(transform->getLocalOrientation()));
+         ImGui::Text("Rotation");
+         ImGui::SameLine(75);
+         if (ImGui::DragFloat3("##Rotation", glm::value_ptr(rotation), 0.1f)) {
+
+            transform->setLocalOrientation(glm::quat(glm::radians(rotation)));
+         }
+
+         // Scale
+         glm::vec3 scale = transform->getLocalScale();
+         ImGui::Text("Scale");
+         ImGui::SameLine(75);
+         if (ImGui::DragFloat3("##Scale", glm::value_ptr(scale), 0.1f)) {
+            transform->setLocalScale(scale);
+         }
+      }
+   }
+}


### PR DESCRIPTION
Entities can be dragged within the hierarchy window, or can be dragged to the parent field in the inspector. If reparenting would cause a hierarchy loop then an error is printed to the Console. Root cannot be reparented.